### PR TITLE
Fix: Update namespace in userscript header

### DIFF
--- a/dist/comic-viewer-helper.user.js
+++ b/dist/comic-viewer-helper.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Magazine Comic Viewer Helper
-// @namespace    https://something/
+// @namespace    https://github.com/kuchida1981/comic-viewer-helper
 // @version      1.0.0
 // @description  A Tampermonkey script for specific comic sites that fits images to the viewport and enables precise image-by-image scrolling.
 // @match        https://something/magazine/*

--- a/src/header.js
+++ b/src/header.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Magazine Comic Viewer Helper
-// @namespace    https://something/
+// @namespace    https://github.com/kuchida1981/comic-viewer-helper
 // @version      1.0.0
 // @description  A Tampermonkey script for specific comic sites that fits images to the viewport and enables precise image-by-image scrolling.
 // @match        https://something/magazine/*


### PR DESCRIPTION
The namespace in both the distribution and source headers was updated from "https://something/" to "https://github.com/kuchida1981/comic-viewer-helper". This change aligns the namespace with the project's GitHub repository, providing a more accurate and identifiable origin for the script.
