### PR TITLE
chore: bump version to 1.2.0 for v1.2 development cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comic-viewer-helper",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "A Tampermonkey/Greasemonkey user script for specific comic sites. It automatically fits images to the browser viewport and enables comfortable image-by-image scrolling.",
   "main": "src/main.js",
   "scripts": {


### PR DESCRIPTION
新しいリリース戦略の導入に伴い、次期リリース v1.2.0 に向けた開発サイクルを開始するためバージョンを更新します。
この PR マージ後、master への変更は自動的に `1.2.0-unstable.[commit-hash]` としてデプロイされます。