### PR TITLE
chore: Bump version to 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comic-viewer-helper",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comic-viewer-helper",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.39.2",


### PR DESCRIPTION
Updates the project version in `package-lock.json` from 1.4.0 to 1.4.1.
