### PR TITLE
chore: Set IS_UNSTABLE env var for pre-commit build

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -21,5 +21,5 @@ run_quietly() {
 run_quietly "lint" npm run lint
 run_quietly "type check" npm run check-types
 run_quietly "test" npm run test
-run_quietly "build" npm run build
+run_quietly "build" env IS_UNSTABLE=true npm run build
 run_quietly "openspec validation" npx openspec validate --strict --all


### PR DESCRIPTION
Modifies the `.husky/pre-commit` hook to prepend `env IS_UNSTABLE=true` to the `npm run build` command.

This change is typically made to:
* Allow the build process to complete even if certain "stable" conditions are not met, preventing the hook from blocking commits.
* Enable a faster or more lenient build specifically for the pre-commit context, avoiding lengthy or overly strict checks during development.
* Signal the build script to use specific configurations or skip certain checks suitable for an "unstable" or development environment.
